### PR TITLE
Add vulkan drivers and gpu device to backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     environment:
       - EXPRESS_PORT=3000
       - SOCKET_IO_PORT=1555
+    #devices:
+      #- /dev/dri/renderD128:/dev/dri/renderD128 # intel gpu, unsure if works for others
 
 networks:
   teemii-network:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -73,7 +73,7 @@ RUN apt-get update && \
     xdg-utils \
     imagemagick \
     libvulkan1 \
-    mesa-vulkan drivers && \
+    mesa-vulkan-drivers && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     mkdir -p /root/db
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -72,7 +72,8 @@ RUN apt-get update && \
     unzip \
     xdg-utils \
     imagemagick \
-    libvulkan1 && \
+    libvulkan1 \
+    mesa-vulkan drivers && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     mkdir -p /root/db
 


### PR DESCRIPTION
#### Description

Add support for gpu acceleration of waifu2x by including mesa-vulkan-drivers in the backend and adding the device declarations to the docker-compose.yml (commented by default)

I can only test with/provide examples for intel gpu, but others shouldn't be too hard.