### PR TITLE
Add custom backend host in container variable

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -28,9 +28,12 @@ RUN npm run build
 # Production stage
 FROM nginx:stable-alpine AS production-stage
 
+# Set default environment variables
+ENV BACKEND_HOST=teemii-backend
+
 # Copy built content from the build stage
 COPY --from=build-stage /app/dist /usr/share/nginx/html
-COPY default.conf /etc/nginx/conf.d/default.conf
+COPY default.conf.template /etc/nginx/templates/default.conf.template
 
 # Expose port 80
 EXPOSE 80

--- a/app/default.conf.template
+++ b/app/default.conf.template
@@ -7,7 +7,7 @@ server {
     }
 
     location /api {
-        proxy_pass http://teemii-backend:3000;
+        proxy_pass http://${BACKEND_HOST}:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -16,7 +16,7 @@ server {
     }
 
     location /socket.io {
-        proxy_pass http://teemii-backend:1555;
+        proxy_pass http://${BACKEND_HOST}:1555;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       - VITE_APP_TITLE=Teemii
       - VITE_APP_PORT=80
+      - BACKEND_HOST=teemii-backend
 
   teemii-backend:
     image: dokkaner/teemii-backend:latest


### PR DESCRIPTION
-------

#### Description
Add a BACKEND_HOST variable to be able to change the name of the backend upstream on the fronted.

This uses nginx container templating capabilities. This is not a feature of
nginx as an application, but a script that is part of the official nginx
container.

#### Screenshot (if UI-related)

#### To-Dos

## backend
- [ ] Successful build `npm run lint`
- [ ] Successful test `npm run test`
- [ ] Database migration (if required)

## frontend
- [X] Successful build `npm run build`

#### Issues Fixed or Closed

- Fixes #67